### PR TITLE
Adding "keepOpen", improving appearance of icons.

### DIFF
--- a/io-menu-option.css
+++ b/io-menu-option.css
@@ -26,6 +26,9 @@
 #label {
   margin: 0 0.8em 0 0;
 }
+#label.has-icon {
+  margin-right: 1.8em;
+}
 #secondary-label {
   color: #aaa;
 }

--- a/io-menu-option.html
+++ b/io-menu-option.html
@@ -39,12 +39,13 @@ It is automatically created by io-menu.
         parentHeight="{{rect.heigh}}"
         parentWidth="{{rect.width}}"
         tooltip="{{tooltip}}"
+        keepOpen="{{keepOpen}}"
         autoExpand
         issubmenu>
       </io-menu>
     </template>
     <template if="{{icon}}"><core-icon icon="{{icon}}"></core-icon></template>
-    <span id="label">{{label}}</span>
+    <span id="label" class="{{icon ? 'has-icon' : ''}}">{{label}}</span>
     <!-- <template if="{{options.length}}"><core-icon icon="chevron-right"></core-icon></template> -->
     <template if="{{secondaryLabel}}"><div id="secondary-label">{{secondaryLabel}}</div></template>
   </template>
@@ -105,6 +106,15 @@ It is automatically created by io-menu.
          * @default null
          */
         action: null,
+
+        /**
+         * Should the menu stay open when an action is selected/clicked?
+         *
+         * @attribute keepOpen
+         * @type boolean
+         * @default false
+         */
+        keepOpen: {value: false, reflect: true},
 
         /**
          * Reference to a button element in case the action requires button to be clicked.

--- a/io-menu.html
+++ b/io-menu.html
@@ -480,7 +480,8 @@ Example:
           option: option,
           label: option.label,
           action: option.action,
-          arguments: option.arguments
+          arguments: option.arguments,
+          tooltip: option.tooltip
         });
       },
 

--- a/io-menu.html
+++ b/io-menu.html
@@ -71,6 +71,7 @@ Example:
             button="{{option.button}}"
             arguments="{{option.arguments}}"
             disabled="{{option.disabled}}"
+            keepOpen="{{option.keepOpen}}"
             tooltip="{{option.tooltip}}"
             autoExpand="{{option.autoExpand || autoExpand}}"
             horizontal="{{option.horizontal}}">
@@ -136,6 +137,15 @@ Example:
         fixed: {value: false, reflect: true},
 
         /**
+         * Should the menu stay open when an action is selected/clicked?
+         *
+         * @attribute keepOpen
+         * @type boolean
+         * @default false
+         */
+        keepOpen: {value: false, reflect: true},
+
+        /**
          * Number of milliseconds before swithcing options when cursor is moving sideways.
          *
          * @attribute holdTime
@@ -184,6 +194,7 @@ Example:
         search: {value: false, reflect: true},
         searchString: '',
         filteredOptions: [],
+
         /**
          * Tooltip to be displayed with the option
          *
@@ -212,7 +223,7 @@ Example:
         'mousedown': 'onDown',
         'mousemove': 'onHover',
         'touchmove': 'onHover',
-        'io-menu-option-clicked': 'collapse',
+        'io-menu-option-clicked': 'handleAction',
         'io-change-option': 'onChangeOption'
       },
       ready: function() {
@@ -410,6 +421,12 @@ Example:
             break;
         }
 
+      },
+      handleAction: function(event) {
+        if (!this.keepOpen) {
+          this.collapse(event);
+        }
+        event.stopPropagation();
       },
       collapseFromOverlay: function(event) {
         if (event.path[0] !== overlayLayer) return;


### PR DESCRIPTION
Added "keepOpen" option that allows a menu to remain open when its options are clicked, gave menu icons a bit more space.